### PR TITLE
 balanceFormat.calcSi with optional decimals

### DIFF
--- a/packages/ui-util/README.md
+++ b/packages/ui-util/README.md
@@ -14,3 +14,10 @@ formatBalance.setDefaults({
 
 formatBalance('12345'); // 12.345z DOT
 ```
+
+## calcSi
+
+```js
+// calculates the SI unit applucable
+formatBalance.calcSi('12345'); // { power: 3, value: 'k', text: 'Kilo' }
+```

--- a/packages/ui-util/src/formatBalance.ts
+++ b/packages/ui-util/src/formatBalance.ts
@@ -15,7 +15,7 @@ type Defaults = {
 
 interface BalanceFormatter {
   (input?: number | string | BN, withSi?: boolean, decimals?: number): string;
-  calcSi (text: string, decimals: number): SiDef;
+  calcSi (text: string, decimals?: number): SiDef;
   findSi (type: string): SiDef;
   getDefaults (): Defaults;
   getOptions (decimals?: number): Array<SiDef>;
@@ -56,7 +56,8 @@ function _formatBalance (input?: number | string | BN, withSi: boolean = true, d
 
 const formatBalance = _formatBalance as BalanceFormatter;
 
-formatBalance.calcSi = calcSi;
+formatBalance.calcSi = (text: string, decimals: number = defaultDecimals): SiDef =>
+  calcSi(text, decimals);
 formatBalance.findSi = findSi;
 
 formatBalance.getDefaults = (): Defaults => {


### PR DESCRIPTION
If not set, use defaults as set via `balanceFormat.setDefaults`