### PR TITLE
Add styled components to dependencies

### DIFF
--- a/packages/ui-identicon/package.json
+++ b/packages/ui-identicon/package.json
@@ -15,7 +15,8 @@
     "@types/react-copy-to-clipboard": "^4.2.6",
     "color": "^3.0.0",
     "jdenticon": "^2.1.1",
-    "react-copy-to-clipboard": "^5.0.1"
+    "react-copy-to-clipboard": "^5.0.1",
+    "styled-components": "^4.1.3"
   },
   "peerDependencies": {
     "@polkadot/keyring": "*",

--- a/packages/ui-keyring/package.json
+++ b/packages/ui-keyring/package.json
@@ -13,7 +13,8 @@
     "@babel/runtime": "^7.3.4",
     "@types/store": "^2.0.1",
     "rxjs": "^6.4.0",
-    "store": "^2.0.12"
+    "store": "^2.0.12",
+    "styled-components": "^4.1.3"
   },
   "devDependencies": {
     "@polkadot/keyring": "^0.39.0-beta.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12587,9 +12587,9 @@ typedoc@^0.14.2:
     typescript "3.2.x"
 
 typescript@3.2.x, typescript@^3.3.3333, typescript@^3.3.4000:
-  version "3.3.3333"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
-  integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
+  version "3.3.4000"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
+  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
I tried to use the `ui-identicon` package in my workshop tutorial and got an error message because styled-components is used in the package, but not listed as a dependency.

The same was true for the `ui-keyring` package. I added it in both packages.