### PR TITLE
Replace isUndefined util with explicit typeof check

### DIFF
--- a/packages/ui-settings/src/defaults.ts
+++ b/packages/ui-settings/src/defaults.ts
@@ -5,6 +5,7 @@
 import { Options } from './types';
 
 // matches https://polkadot.js.org & https://poc-3.polkadot.io
+ // tslint:disable-next-line
 const isPolkadot = typeof window !== 'undefined' && window.location.host.indexOf('polkadot') !== -1;
 
 const WSS_POLKADOT = 'wss://poc3-rpc.polkadot.io/';
@@ -44,6 +45,7 @@ const UITHEME_DEFAULT = isPolkadot
   ? 'polkadot'
   : 'substrate';
 
+// tslint:disable-next-line
 const UIMODE_DEFAULT = !isPolkadot && typeof window !== 'undefined' && window.location.host.indexOf('ui-light') !== -1
   ? 'light'
   : 'full';

--- a/packages/ui-settings/src/defaults.ts
+++ b/packages/ui-settings/src/defaults.ts
@@ -2,12 +2,10 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { isUndefined } from '@polkadot/util';
-
 import { Options } from './types';
 
 // matches https://polkadot.js.org & https://poc-3.polkadot.io
-const isPolkadot = !isUndefined(window) && window.location.host.indexOf('polkadot') !== -1;
+const isPolkadot = typeof window !== 'undefined' && window.location.host.indexOf('polkadot') !== -1;
 
 const WSS_POLKADOT = 'wss://poc3-rpc.polkadot.io/';
 const WSS_SUBSTRATE = 'wss://substrate-rpc.parity.io/';
@@ -46,7 +44,7 @@ const UITHEME_DEFAULT = isPolkadot
   ? 'polkadot'
   : 'substrate';
 
-const UIMODE_DEFAULT = !isPolkadot && !isUndefined(window) && window.location.host.indexOf('ui-light') !== -1
+const UIMODE_DEFAULT = !isPolkadot && typeof window !== 'undefined' && window.location.host.indexOf('ui-light') !== -1
   ? 'light'
   : 'full';
 


### PR DESCRIPTION
Typescript (or Babel) compiles our util function `isUndefined( value )` to this `!(0, _util.isUndefined)(window)`.

This check is failing if `window` is not defined because it's trying to pass a undeclared variable :|