### PR TITLE
Bump deps, re-encode old addresses

### DIFF
--- a/packages/ui-identicon/package.json
+++ b/packages/ui-identicon/package.json
@@ -24,8 +24,8 @@
     "react": "*"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^0.90.1",
-    "@polkadot/util-crypto": "^0.90.1",
+    "@polkadot/keyring": "^0.91.0-beta.1",
+    "@polkadot/util-crypto": "^0.91.0-beta.1",
     "xmlserializer": "^0.6.1"
   }
 }

--- a/packages/ui-keyring/package.json
+++ b/packages/ui-keyring/package.json
@@ -16,9 +16,9 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^0.90.1",
-    "@polkadot/types": "^0.78.1",
-    "@polkadot/util": "^0.90.1"
+    "@polkadot/keyring": "^0.91.0-beta.1",
+    "@polkadot/types": "^0.79.0-beta.6",
+    "@polkadot/util": "^0.91.0-beta.1"
   },
   "peerDependencies": {
     "@polkadot/keyring": "*",

--- a/packages/ui-keyring/src/defaults.ts
+++ b/packages/ui-keyring/src/defaults.ts
@@ -11,7 +11,8 @@ const MAX_PASS_LEN = 32;
 
 function toHex (address: string): string {
   return u8aToHex(
-    decodeAddress(address)
+    // When saving pre-checksum changes, ensure that we can decode
+    decodeAddress(address, true)
   );
 }
 

--- a/packages/ui-settings/package.json
+++ b/packages/ui-settings/package.json
@@ -14,7 +14,7 @@
     "store": "^2.0.12"
   },
   "devDependencies": {
-    "@polkadot/util": "^0.90.1"
+    "@polkadot/util": "^0.91.0-beta.1"
   },
   "peerDependencies": {
     "@polkadot/util": "*"

--- a/packages/ui-util/package.json
+++ b/packages/ui-util/package.json
@@ -12,7 +12,7 @@
     "@babel/runtime": "^7.4.4"
   },
   "devDependencies": {
-    "@polkadot/types": "^0.78.1"
+    "@polkadot/types": "^0.79.0-beta.6"
   },
   "peerDependencies": {
     "@polkadot/types": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1838,14 +1838,14 @@
     typescript "^3.4.5"
     vuepress "^1.0.0-alpha.47"
 
-"@polkadot/keyring@^0.90.1":
-  version "0.90.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-0.90.1.tgz#ad8c499eebfaebfdd02da4ed4b56e171e76a58f4"
-  integrity sha512-wOfZPFrsbuTRlzmDw632tI66UbAW8rZnUFFHACjIBwiUgwy+KAgygCJtmZR1PcEn7O+dfDImrxcu34cSagBQXQ==
+"@polkadot/keyring@^0.91.0-beta.1":
+  version "0.91.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-0.91.0-beta.1.tgz#b18d5c4e983e76ca9cfc8636a917e7bfeeec2737"
+  integrity sha512-leCcCoPOhiUhQhHhwvuWkgUxd788axqaQcN/36xRAkn/cv8/DFdbrUDMhafJCjAWATJMhegMneDwW+F+rsmn4w==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@polkadot/util" "^0.90.1"
-    "@polkadot/util-crypto" "^0.90.1"
+    "@polkadot/util" "^0.91.0-beta.1"
+    "@polkadot/util-crypto" "^0.91.0-beta.1"
     "@types/bs58" "^4.0.0"
     bs58 "^4.0.1"
 
@@ -1854,23 +1854,23 @@
   resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.56.tgz#ffd6e9c95704a7fb90b918193b9dc5c440114b27"
   integrity sha512-wnt4zXxZXyz6WaubTO/I+nUElwV2DogFzdl6CrKfVn2PTWp8uHN06W9s40FH57ORtmQfDr9rLRP8Nq+oIyElbg==
 
-"@polkadot/types@^0.78.1":
-  version "0.78.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.78.1.tgz#0de981775e98dd7fb8b29f839869ac7df836f0d4"
-  integrity sha512-Py1VuaAy5KwvpaPsVEQoTSk63JrIE/AgrLvcz8SOu9SKe5TUy57SE9u/ztqxEEW+AtDaN5q+fVzvKD3qn9S0og==
+"@polkadot/types@^0.79.0-beta.6":
+  version "0.79.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.79.0-beta.6.tgz#cdbe76b88c3eed125091e23ee9663bea15a5a44a"
+  integrity sha512-1JK9IjuJcWjhzuIX/DrYkXhIDyo03R+xV60/8kzfdPz2OErnG4c1/KYFmfeScRqr9wKCR6BqRh3BGS6fo8oTGw==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@polkadot/keyring" "^0.90.1"
-    "@polkadot/util" "^0.90.1"
+    "@polkadot/keyring" "^0.91.0-beta.1"
+    "@polkadot/util" "^0.91.0-beta.1"
 
-"@polkadot/util-crypto@^0.90.1":
-  version "0.90.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-0.90.1.tgz#2cec2f43995a8dca2f736a920b34fb3270bdeb02"
-  integrity sha512-sF8xTPWNdbJ/NZsAWpGVQFSnYlm4tkV60xYLz93CH0AjWky6A1TXNYzfvIZV91I0BzEQPCt3pCSRzVlsLdG4Ww==
+"@polkadot/util-crypto@^0.91.0-beta.1":
+  version "0.91.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-0.91.0-beta.1.tgz#d2c387f3a3e1b8563fdcc27765f960511bb76c17"
+  integrity sha512-+/05Dx1mM8Kt2938ile6O74OwOpeVutBuzGUnEm7o5C8B0FAwj0wOSho9peUzuc38xHS/+M3pEDDNkE2iAHmdA==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@polkadot/util" "^0.90.1"
-    "@polkadot/wasm-crypto" "^0.9.1"
+    "@polkadot/util" "^0.91.0-beta.1"
+    "@polkadot/wasm-crypto" "^0.10.1"
     "@types/bip39" "^2.4.2"
     "@types/pbkdf2" "^3.0.0"
     "@types/secp256k1" "^3.5.0"
@@ -1883,10 +1883,10 @@
     tweetnacl "^1.0.1"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@^0.90.1":
-  version "0.90.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.90.1.tgz#25f4f1bd1702cb12f10b8f94de5b79d4eda98ed9"
-  integrity sha512-vquT0fnBycm1jCG9gpLkJruLmA1J4P1nJvmvoLfZn5lDI4IChgwoK2rv9aDDfEfO/sYIRUqyiuMiT9TwzL2udA==
+"@polkadot/util@^0.91.0-beta.1":
+  version "0.91.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.91.0-beta.1.tgz#02a2dc4cab18d1a8e8ba95ae1e5b311810d47108"
+  integrity sha512-ROfNksTqj68EMD+zuHPuuX/neb3fW5FjaGmpsUHVeIANb6wwHc9XJFEwij026FJhiOT0ZPNNDJ5e/x+dmJ8slg==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@types/bn.js" "^4.11.5"
@@ -1898,10 +1898,10 @@
     ip-regex "^4.1.0"
     moment "^2.24.0"
 
-"@polkadot/wasm-crypto@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-0.9.1.tgz#8c92fb3ab10a010d9894623958845b4047539d86"
-  integrity sha512-CBMzj71z5Stk0kvtpIMGHSTut9OJwscYkgPeyML14kJ1FLipm+p6qz83zXKqvMbPLiCBKXZwDpKiVlMwwmBaPA==
+"@polkadot/wasm-crypto@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-0.10.1.tgz#284e57e102050cca1586b7b1f008f64224147eb4"
+  integrity sha512-hI3OYftMGJkDetTe1DeU9aH4euk6WVmAMFszslNrCxHMFFkemEgACykwpyuOdCjv24VZP/cMsrVskKix1GzSYQ==
 
 "@types/babel__core@^7.1.0":
   version "7.1.1"


### PR DESCRIPTION
When editing old addresses, it would use the json address - which could have the incorrect checksum. Found as part of https://github.com/polkadot-js/apps/pull/1142