### PR TITLE
KeyringStore interface

### DIFF
--- a/packages/ui-keyring/src/Base.ts
+++ b/packages/ui-keyring/src/Base.ts
@@ -5,7 +5,7 @@
 import { Prefix } from '@polkadot/keyring/address/types';
 import { KeyringInstance, KeyringPair } from '@polkadot/keyring/types';
 import { AddressSubject } from './observable/types';
-import { KeyringOptions } from './types';
+import { KeyringOptions, KeyringStore } from './types';
 
 import testKeyring from '@polkadot/keyring/testing';
 import { isBoolean, isString } from '@polkadot/util';
@@ -13,6 +13,7 @@ import { isBoolean, isString } from '@polkadot/util';
 import accounts from './observable/accounts';
 import addresses from './observable/addresses';
 import env from './observable/development';
+import LocalStorageStore from './stores/LocalStorage';
 import { MAX_PASS_LEN } from './defaults';
 
 export default class Base {
@@ -20,11 +21,13 @@ export default class Base {
   private _addresses: AddressSubject;
   private _keyring?: KeyringInstance;
   private _prefix?: Prefix;
+  protected _store: KeyringStore;
 
   constructor () {
     this._accounts = accounts;
     this._addresses = addresses;
     this._keyring = undefined;
+    this._store = null as any;
   }
 
   get accounts () {
@@ -91,6 +94,7 @@ export default class Base {
     }
 
     this._keyring = keyring;
+    this._store = options.store || new LocalStorageStore();
 
     this.addAccountPairs();
   }

--- a/packages/ui-keyring/src/stores/LocalStorage.ts
+++ b/packages/ui-keyring/src/stores/LocalStorage.ts
@@ -1,0 +1,29 @@
+// Copyright 2017-2019 @polkadot/ui-keyring authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { KeyringStore } from '../types';
+
+import store from 'store';
+
+export default class Store implements KeyringStore {
+  all (cb: (key: string, value: any) => void): void {
+    store.each((value: any, key: string) =>
+      cb(key, value)
+    );
+  }
+
+  get (key: string, cb: (value: any) => void): void {
+    cb(store.get(key));
+  }
+
+  remove (key: string, cb?: () => void): void {
+    store.remove(key);
+    cb && cb();
+  }
+
+  set (key: string, value: any, cb?: () => void): void {
+    store.set(key, value);
+    cb && cb();
+  }
+}

--- a/packages/ui-keyring/src/types.ts
+++ b/packages/ui-keyring/src/types.ts
@@ -6,8 +6,16 @@ import { KeyringInstance as BaseKeyringInstance, KeyringPair, KeyringPair$Meta, 
 import { KeypairType } from '@polkadot/util-crypto/types';
 import { AddressSubject, SingleAddress } from './observable/types';
 
+export interface KeyringStore {
+  all: (cb: (key: string, value: any) => void) => void;
+  get: (key: string, cb: (value: any) => void) => void;
+  remove: (key: string, cb?: () => void) => void;
+  set: (key: string, value: any, cb?: () => void) => void;
+}
+
 export type KeyringOptions = KeyringOptionsBase & {
-  isDevelopment?: boolean
+  isDevelopment?: boolean,
+  store?: KeyringStore
 };
 
 export type KeyringJson$Meta = {

--- a/packages/ui-util/package.json
+++ b/packages/ui-util/package.json
@@ -12,7 +12,7 @@
     "@babel/runtime": "^7.4.4"
   },
   "devDependencies": {
-    "@polkadot/types": "^0.79.0-beta.6"
+    "@polkadot/types": "^0.79.0-beta.31"
   },
   "peerDependencies": {
     "@polkadot/types": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,10 +1854,10 @@
   resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.56.tgz#ffd6e9c95704a7fb90b918193b9dc5c440114b27"
   integrity sha512-wnt4zXxZXyz6WaubTO/I+nUElwV2DogFzdl6CrKfVn2PTWp8uHN06W9s40FH57ORtmQfDr9rLRP8Nq+oIyElbg==
 
-"@polkadot/types@^0.79.0-beta.6":
-  version "0.79.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.79.0-beta.6.tgz#cdbe76b88c3eed125091e23ee9663bea15a5a44a"
-  integrity sha512-1JK9IjuJcWjhzuIX/DrYkXhIDyo03R+xV60/8kzfdPz2OErnG4c1/KYFmfeScRqr9wKCR6BqRh3BGS6fo8oTGw==
+"@polkadot/types@^0.79.0-beta.31":
+  version "0.79.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.79.0-beta.31.tgz#3e66dec097653a17386f687a70a86bc2520894ea"
+  integrity sha512-ibVRBIirFCUYSQsMFBLSNGl0hp86tWM2RXnx3MDT5WiX4qGUOEy5aKTFU+hCDC8NhHa5+oNw8EeIDZ3waRI/4g==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@polkadot/keyring" "^0.91.0-beta.1"


### PR DESCRIPTION
Add `KeyringStore` interface and use it - this interface is compatible with localStorage as well as Chrome (e.g. https://developer.chrome.com/apps/storage#type-StorageArea) via interface adaption. (Only LocalStorage added here, stores to be supplied)

Addresses some of https://github.com/polkadot-js/ui/issues/124 - however specifically done for extension usage with the Chrome APIs. (So tweaks are probably needed along the way)