### PR TITLE
Add Edgeware chain prefix to settings.

### DIFF
--- a/packages/ui-settings/src/defaults/ss58.ts
+++ b/packages/ui-settings/src/defaults/ss58.ts
@@ -26,5 +26,10 @@ export const PREFIXES: Option[] = [
     info: 'polkadot',
     text: 'Polkadot (live)',
     value: 0
+  },
+  {
+    info: 'edgeware',
+    text: 'Edgeware (live)',
+    value: 7
   }
 ];


### PR DESCRIPTION
Adds Edgeware's SS58 prefix of "7" to the settings dropdown (although testnet still uses "42" prefix/Substrate dev).