### PR TITLE
allow qr to scan seed qr

### DIFF
--- a/packages/react-qr/src/ScanAddress.tsx
+++ b/packages/react-qr/src/ScanAddress.tsx
@@ -2,17 +2,18 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { BaseProps } from './types';
-
-import React, { useCallback } from 'react';
 import { assert } from '@polkadot/util';
 import { decodeAddress } from '@polkadot/util-crypto';
 
-import { ADDRESS_PREFIX } from './constants';
+import React, { useCallback } from 'react';
+
+import { ADDRESS_PREFIX, SEED_PREFIX } from './constants';
 import QrScan from './Scan';
+import { BaseProps } from './types';
 
 interface ScanType {
-  address: string;
+  isAddress: boolean;
+  content: string;
   genesisHash: string;
   name?: string;
 }
@@ -30,12 +31,16 @@ function ScanAddress ({ className, onError, onScan, size, style }: Props): React
       }
 
       try {
-        const [prefix, address, genesisHash, name] = data.split(':');
+        const [prefix, content, genesisHash, name] = data.split(':');
 
-        assert(prefix === ADDRESS_PREFIX, `Invalid address received, expected '${ADDRESS_PREFIX}', found '${prefix}'`);
+        assert(prefix === ADDRESS_PREFIX || prefix === SEED_PREFIX, `Invalid prefix received, expected '${ADDRESS_PREFIX}/${SEED_PREFIX}' , found '${prefix}'`);
+        const isAddress = prefix === ADDRESS_PREFIX;
 
-        decodeAddress(address);
-        onScan({ address, genesisHash, name });
+        if (isAddress) {
+          decodeAddress(content);
+        }
+
+        onScan({ content, genesisHash, isAddress, name });
       } catch (error) {
         console.error('@polkadot/react-qr:QrScanAddress', (error as Error).message, data);
       }

--- a/packages/react-qr/src/ScanAddress.tsx
+++ b/packages/react-qr/src/ScanAddress.tsx
@@ -2,14 +2,14 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { BaseProps } from './types';
+
+import React, { useCallback } from 'react';
 import { assert } from '@polkadot/util';
 import { decodeAddress } from '@polkadot/util-crypto';
 
-import React, { useCallback } from 'react';
-
 import { ADDRESS_PREFIX, SEED_PREFIX } from './constants';
 import QrScan from './Scan';
-import { BaseProps } from './types';
 
 interface ScanType {
   isAddress: boolean;
@@ -35,6 +35,7 @@ function ScanAddress ({ className, onError, onScan, size, style }: Props): React
         const isValidPrefix = prefix === ADDRESS_PREFIX || prefix === SEED_PREFIX;
 
         assert(isValidPrefix, `Invalid prefix received, expected '${ADDRESS_PREFIX}/${SEED_PREFIX}' , found '${prefix}'`);
+        
         const isAddress = prefix === ADDRESS_PREFIX;
 
         if (isAddress) {

--- a/packages/react-qr/src/ScanAddress.tsx
+++ b/packages/react-qr/src/ScanAddress.tsx
@@ -32,8 +32,9 @@ function ScanAddress ({ className, onError, onScan, size, style }: Props): React
 
       try {
         const [prefix, content, genesisHash, name] = data.split(':');
+        const isValidPrefix = prefix === ADDRESS_PREFIX || prefix === SEED_PREFIX;
 
-        assert(prefix === ADDRESS_PREFIX || prefix === SEED_PREFIX, `Invalid prefix received, expected '${ADDRESS_PREFIX}/${SEED_PREFIX}' , found '${prefix}'`);
+        assert(isValidPrefix, `Invalid prefix received, expected '${ADDRESS_PREFIX}/${SEED_PREFIX}' , found '${prefix}'`);
         const isAddress = prefix === ADDRESS_PREFIX;
 
         if (isAddress) {

--- a/packages/react-qr/src/ScanAddress.tsx
+++ b/packages/react-qr/src/ScanAddress.tsx
@@ -35,7 +35,7 @@ function ScanAddress ({ className, onError, onScan, size, style }: Props): React
         const isValidPrefix = prefix === ADDRESS_PREFIX || prefix === SEED_PREFIX;
 
         assert(isValidPrefix, `Invalid prefix received, expected '${ADDRESS_PREFIX}/${SEED_PREFIX}' , found '${prefix}'`);
-        
+
         const isAddress = prefix === ADDRESS_PREFIX;
 
         if (isAddress) {

--- a/packages/react-qr/src/constants.ts
+++ b/packages/react-qr/src/constants.ts
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 const ADDRESS_PREFIX = 'substrate';
+const SEED_PREFIX = 'secret';
 const FRAME_SIZE = 1024;
 const SUBSTRATE_ID = new Uint8Array([0x53]);
 const CRYPTO_SR25519 = new Uint8Array([0x01]);
@@ -19,5 +20,6 @@ export {
   CMD_SIGN_MSG,
   CRYPTO_SR25519,
   FRAME_SIZE,
+  SEED_PREFIX,
   SUBSTRATE_ID
 };


### PR DESCRIPTION
This PR support the feature on https://github.com/polkadot-js/apps/issues/2885, which enable the qr scanner with data format:

`secret:${mini_secret_key}:${genesisHash}:${name}`