### PR TITLE
Export a dedicated type for icon theme

### DIFF
--- a/packages/react-identicon/src/types.ts
+++ b/packages/react-identicon/src/types.ts
@@ -25,6 +25,8 @@ export interface IdentityProps extends BaseProps {
   onCopy?: (value: string) => void;
   prefix?: Prefix;
   size?: number;
-  theme?: 'beachball' | 'empty' | 'ethereum' | 'jdenticon' | 'polkadot' | 'substrate';
+  theme?: IconTheme;
   value?: string | Uint8Array | null;
 }
+
+export type IconTheme = 'beachball' | 'empty' | 'ethereum' | 'jdenticon' | 'polkadot' | 'substrate';


### PR DESCRIPTION
Adds an explicit type for the list of accepted icon themes to make importing this list nicer than `IdentityProps['theme']`