### PR TITLE
add new type in api - settings in order to support different types of…

### DIFF
--- a/packages/ui-settings/src/Settings.ts
+++ b/packages/ui-settings/src/Settings.ts
@@ -24,9 +24,9 @@ function withDefault (options: Option[], option: string | undefined, fallback: s
 export class Settings implements SettingsStruct {
   readonly #emitter: EventEmitter;
 
-  #apiTypeUrl: Endpoint;
+  #apiType: Endpoint;
 
-  // will become deprecated for supporting substrate connect light clients. apiTypeUrl structure should be used instead
+  // will become deprecated for supporting substrate connect light clients. apiType structure should be used instead
   #apiUrl: string;
 
   #camera: string;
@@ -50,8 +50,8 @@ export class Settings implements SettingsStruct {
 
     this.#emitter = new EventEmitter();
 
-    this.#apiTypeUrl = { type: EndpointType.jrpc, url: this.#apiUrl };
-    // will become deprecated for supporting substrate connect light clients. apiTypeUrl structure should be used instead
+    this.#apiType = { type: EndpointType.jrpc, url: this.#apiUrl };
+    // will become deprecated for supporting substrate connect light clients. apiType structure should be used instead
     this.#apiUrl = (typeof settings.apiUrl === 'string' && settings.apiUrl) || process.env.WS_URL || (ENDPOINT_DEFAULT.value as string);
     this.#camera = withDefault(CAMERA, settings.camera, CAMERA_DEFAULT);
     this.#ledgerConn = withDefault(LEDGER_CONN, settings.ledgerConn, LEDGER_CONN_DEFAULT);
@@ -67,8 +67,8 @@ export class Settings implements SettingsStruct {
     return this.#camera;
   }
 
-  public get apiTypeUrl (): Endpoint {
-    return this.#apiTypeUrl;
+  public get apiType (): Endpoint {
+    return this.#apiType;
   }
 
   public get apiUrl (): string {
@@ -149,7 +149,7 @@ export class Settings implements SettingsStruct {
 
   public get (): SettingsStruct {
     return {
-      apiTypeUrl: this.#apiTypeUrl,
+      apiType: this.#apiType,
       apiUrl: this.#apiUrl,
       camera: this.#camera,
       i18nLang: this.#i18nLang,
@@ -163,7 +163,7 @@ export class Settings implements SettingsStruct {
   }
 
   public set (settings: Partial<SettingsStruct>): void {
-    this.#apiTypeUrl = settings.apiTypeUrl || this.#apiTypeUrl;
+    this.#apiType = settings.apiType || this.#apiType;
     this.#apiUrl = settings.apiUrl || this.#apiUrl;
     this.#camera = settings.camera || this.#camera;
     this.#ledgerConn = settings.ledgerConn || this.#ledgerConn;

--- a/packages/ui-settings/src/Settings.ts
+++ b/packages/ui-settings/src/Settings.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/ui-settings authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Option, SettingsStruct } from './types';
+import { Option, SettingsStruct, Endpoint, EndpointType } from './types';
 
 import EventEmitter from 'eventemitter3';
 import store from 'store';
@@ -24,6 +24,9 @@ function withDefault (options: Option[], option: string | undefined, fallback: s
 export class Settings implements SettingsStruct {
   readonly #emitter: EventEmitter;
 
+  #apiTypeUrl: Endpoint;
+
+  // will become deprecated for supporting substrate connect light clients. apiTypeUrl structure should be used instead
   #apiUrl: string;
 
   #camera: string;
@@ -47,6 +50,8 @@ export class Settings implements SettingsStruct {
 
     this.#emitter = new EventEmitter();
 
+    this.#apiTypeUrl = { type: EndpointType.jrpc, url: this.#apiUrl };
+    // will become deprecated for supporting substrate connect light clients. apiTypeUrl structure should be used instead
     this.#apiUrl = (typeof settings.apiUrl === 'string' && settings.apiUrl) || process.env.WS_URL || (ENDPOINT_DEFAULT.value as string);
     this.#camera = withDefault(CAMERA, settings.camera, CAMERA_DEFAULT);
     this.#ledgerConn = withDefault(LEDGER_CONN, settings.ledgerConn, LEDGER_CONN_DEFAULT);
@@ -60,6 +65,10 @@ export class Settings implements SettingsStruct {
 
   public get camera (): string {
     return this.#camera;
+  }
+
+  public get apiTypeUrl (): Endpoint {
+    return this.#apiTypeUrl;
   }
 
   public get apiUrl (): string {
@@ -140,6 +149,7 @@ export class Settings implements SettingsStruct {
 
   public get (): SettingsStruct {
     return {
+      apiTypeUrl: this.#apiTypeUrl,
       apiUrl: this.#apiUrl,
       camera: this.#camera,
       i18nLang: this.#i18nLang,
@@ -153,6 +163,7 @@ export class Settings implements SettingsStruct {
   }
 
   public set (settings: Partial<SettingsStruct>): void {
+    this.#apiTypeUrl = settings.apiTypeUrl || this.#apiTypeUrl;
     this.#apiUrl = settings.apiUrl || this.#apiUrl;
     this.#camera = settings.camera || this.#camera;
     this.#ledgerConn = settings.ledgerConn || this.#ledgerConn;

--- a/packages/ui-settings/src/Settings.ts
+++ b/packages/ui-settings/src/Settings.ts
@@ -52,7 +52,7 @@ export class Settings implements SettingsStruct {
 
     // will become deprecated for supporting substrate connect light clients. apiType structure should be used instead
     this.#apiUrl = (typeof settings.apiUrl === 'string' && settings.apiUrl) || process.env.WS_URL || (ENDPOINT_DEFAULT.value as string);
-    this.#apiType = { type: 'json-rpc' as EndpointType, url: this.#apiUrl };
+    this.#apiType = { param: this.#apiUrl, type: 'json-rpc' as EndpointType };
     this.#camera = withDefault(CAMERA, settings.camera, CAMERA_DEFAULT);
     this.#ledgerConn = withDefault(LEDGER_CONN, settings.ledgerConn, LEDGER_CONN_DEFAULT);
     this.#i18nLang = settings.i18nLang || LANGUAGE_DEFAULT;

--- a/packages/ui-settings/src/Settings.ts
+++ b/packages/ui-settings/src/Settings.ts
@@ -1,14 +1,13 @@
 // Copyright 2017-2021 @polkadot/ui-settings authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { Option, SettingsStruct, Endpoint, EndpointType } from './types';
-
 import EventEmitter from 'eventemitter3';
 import store from 'store';
 
 import { isUndefined } from '@polkadot/util';
 
 import { CAMERA, CAMERA_DEFAULT, CRYPTOS, CRYPTOS_ETH, CRYPTOS_LEDGER, ENDPOINT_DEFAULT, ENDPOINTS, ICON_DEFAULT, ICONS, LANGUAGE_DEFAULT, LEDGER_CONN, LEDGER_CONN_DEFAULT, LOCKING, LOCKING_DEFAULT, PREFIX_DEFAULT, PREFIXES, UIMODE_DEFAULT, UIMODES, UITHEME_DEFAULT, UITHEMES } from './defaults';
+import { Endpoint, EndpointType, Option, SettingsStruct } from './types';
 
 type ChangeCallback = (settings: SettingsStruct) => void;
 type OnTypes = 'change';

--- a/packages/ui-settings/src/Settings.ts
+++ b/packages/ui-settings/src/Settings.ts
@@ -1,13 +1,14 @@
 // Copyright 2017-2021 @polkadot/ui-settings authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { Endpoint, EndpointType, Option, SettingsStruct } from './types';
+
 import EventEmitter from 'eventemitter3';
 import store from 'store';
 
 import { isUndefined } from '@polkadot/util';
 
 import { CAMERA, CAMERA_DEFAULT, CRYPTOS, CRYPTOS_ETH, CRYPTOS_LEDGER, ENDPOINT_DEFAULT, ENDPOINTS, ICON_DEFAULT, ICONS, LANGUAGE_DEFAULT, LEDGER_CONN, LEDGER_CONN_DEFAULT, LOCKING, LOCKING_DEFAULT, PREFIX_DEFAULT, PREFIXES, UIMODE_DEFAULT, UIMODES, UITHEME_DEFAULT, UITHEMES } from './defaults';
-import { Endpoint, EndpointType, Option, SettingsStruct } from './types';
 
 type ChangeCallback = (settings: SettingsStruct) => void;
 type OnTypes = 'change';
@@ -51,7 +52,7 @@ export class Settings implements SettingsStruct {
 
     // will become deprecated for supporting substrate connect light clients. apiType structure should be used instead
     this.#apiUrl = (typeof settings.apiUrl === 'string' && settings.apiUrl) || process.env.WS_URL || (ENDPOINT_DEFAULT.value as string);
-    this.#apiType = { type: EndpointType.jrpc, url: this.#apiUrl };
+    this.#apiType = { type: 'json-rpc' as EndpointType, url: this.#apiUrl };
     this.#camera = withDefault(CAMERA, settings.camera, CAMERA_DEFAULT);
     this.#ledgerConn = withDefault(LEDGER_CONN, settings.ledgerConn, LEDGER_CONN_DEFAULT);
     this.#i18nLang = settings.i18nLang || LANGUAGE_DEFAULT;

--- a/packages/ui-settings/src/Settings.ts
+++ b/packages/ui-settings/src/Settings.ts
@@ -50,9 +50,9 @@ export class Settings implements SettingsStruct {
 
     this.#emitter = new EventEmitter();
 
-    this.#apiType = { type: EndpointType.jrpc, url: this.#apiUrl };
     // will become deprecated for supporting substrate connect light clients. apiType structure should be used instead
     this.#apiUrl = (typeof settings.apiUrl === 'string' && settings.apiUrl) || process.env.WS_URL || (ENDPOINT_DEFAULT.value as string);
+    this.#apiType = { type: EndpointType.jrpc, url: this.#apiUrl };
     this.#camera = withDefault(CAMERA, settings.camera, CAMERA_DEFAULT);
     this.#ledgerConn = withDefault(LEDGER_CONN, settings.ledgerConn, LEDGER_CONN_DEFAULT);
     this.#i18nLang = settings.i18nLang || LANGUAGE_DEFAULT;

--- a/packages/ui-settings/src/index.ts
+++ b/packages/ui-settings/src/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Settings, settings } from './Settings';
-import { Endpoint, JsonRpcEndpoint, SubstrateConnectEndpoint, EndpointType } from './types';
+import { Endpoint, EndpointType, JsonRpcEndpoint, SubstrateConnectEndpoint } from './types';
 
 export { ENDPOINT_DEFAULT, ICON_DEFAULT, ICON_DEFAULT_HOST, LANGUAGE_DEFAULT, LOCKING_DEFAULT, PREFIX_DEFAULT, UIMODE_DEFAULT, UITHEME_DEFAULT } from './defaults';
 export { packageInfo } from './packageInfo';

--- a/packages/ui-settings/src/index.ts
+++ b/packages/ui-settings/src/index.ts
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Settings, settings } from './Settings';
-import { Endpoint, EndpointType, JsonRpcEndpoint, SubstrateConnectEndpoint } from './types';
 
 export { ENDPOINT_DEFAULT, ICON_DEFAULT, ICON_DEFAULT_HOST, LANGUAGE_DEFAULT, LOCKING_DEFAULT, PREFIX_DEFAULT, UIMODE_DEFAULT, UITHEME_DEFAULT } from './defaults';
 export { packageInfo } from './packageInfo';
 
-export { settings, Settings, Endpoint, JsonRpcEndpoint, SubstrateConnectEndpoint, EndpointType };
+export { settings, Settings };
 
 export default settings;

--- a/packages/ui-settings/src/index.ts
+++ b/packages/ui-settings/src/index.ts
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Settings, settings } from './Settings';
+import { Endpoint, JsonRpcEndpoint, SubstrateConnectEndpoint, EndpointType } from './types';
 
 export { ENDPOINT_DEFAULT, ICON_DEFAULT, ICON_DEFAULT_HOST, LANGUAGE_DEFAULT, LOCKING_DEFAULT, PREFIX_DEFAULT, UIMODE_DEFAULT, UITHEME_DEFAULT } from './defaults';
 export { packageInfo } from './packageInfo';
 
-export { settings, Settings };
+export { settings, Settings, Endpoint, JsonRpcEndpoint, SubstrateConnectEndpoint, EndpointType };
 
 export default settings;

--- a/packages/ui-settings/src/types.ts
+++ b/packages/ui-settings/src/types.ts
@@ -30,18 +30,9 @@ export interface NetworkSpecsStruct {
   unit: string;
 }
 
-export type Endpoint = JsonRpcEndpoint | SubstrateConnectEndpoint;
-export interface JsonRpcEndpoint {
-  type: EndpointType.jrpc;
-  url: string;
+export type Endpoint = {
+  type: EndpointType;
+  param: string;
 }
 
-export interface SubstrateConnectEndpoint {
-  type: EndpointType.substrateconnect;
-  chain: string;
-}
-
-export enum EndpointType {
-  jrpc = 'json-rpc',
-  substrateconnect = 'substrate-connect'
-}
+export type EndpointType = 'json-rpc' | 'substrate-connect';

--- a/packages/ui-settings/src/types.ts
+++ b/packages/ui-settings/src/types.ts
@@ -30,7 +30,7 @@ export interface NetworkSpecsStruct {
   unit: string;
 }
 
-export type Endpoint = {
+export interface Endpoint {
   type: EndpointType;
   param: string;
 }

--- a/packages/ui-settings/src/types.ts
+++ b/packages/ui-settings/src/types.ts
@@ -9,6 +9,7 @@ export type Option = {
 }
 
 export interface SettingsStruct {
+  apiTypeUrl: Endpoint;
   apiUrl: string;
   camera: string;
   i18nLang: string;
@@ -27,4 +28,20 @@ export interface NetworkSpecsStruct {
   prefix: number;
   title: string;
   unit: string;
+}
+
+export type Endpoint = JsonRpcEndpoint | SubstrateConnectEndpoint;
+export interface JsonRpcEndpoint {
+  type: EndpointType.jrpc;
+  url: string;
+}
+
+export interface SubstrateConnectEndpoint {
+  type: EndpointType.substrateconnect;
+  chain: string;
+}
+
+export enum EndpointType {
+  jrpc = 'json-rpc',
+  substrateconnect = 'substrate-connect'
 }

--- a/packages/ui-settings/src/types.ts
+++ b/packages/ui-settings/src/types.ts
@@ -9,7 +9,7 @@ export type Option = {
 }
 
 export interface SettingsStruct {
-  apiTypeUrl: Endpoint;
+  apiType: Endpoint;
   apiUrl: string;
   camera: string;
   i18nLang: string;


### PR DESCRIPTION
… inputs - 'json-rpc' and 'substrate-connect';

 The new format will be: 
 ```
 { type: 'json-rpc', url: 'ws://someUrl' }
 ```
 or
  ```
 { type: 'substrate-connect', chain: 'available network' }
 ```