### PR TITLE
Aadd isEthereum props to ScanAddress to import eth addresses

### DIFF
--- a/packages/react-qr/src/ScanAddress.tsx
+++ b/packages/react-qr/src/ScanAddress.tsx
@@ -31,7 +31,7 @@ function ScanAddress ({ className, isEthereum, onError, onScan, size, style }: P
       if (data) {
         try {
           const [prefix, content, genesisHash, ...name] = data.split(':');
-          const isValidPrefix = isEthereum ? prefix === 'ethereum' : prefix === ADDRESS_PREFIX || prefix === SEED_PREFIX;
+          const isValidPrefix = (prefix === (isEthereum ? 'ethereum' : ADDRESS_PREFIX)) || (prefix === SEED_PREFIX);
 
           assert(isValidPrefix, `Invalid prefix received, expected '${ADDRESS_PREFIX}/${SEED_PREFIX}' , found '${prefix}'`);
 

--- a/packages/react-qr/src/ScanAddress.tsx
+++ b/packages/react-qr/src/ScanAddress.tsx
@@ -22,15 +22,16 @@ interface Props {
   onScan: (scanned: ScanType) => void;
   size?: string | number;
   style?: React.CSSProperties;
+  isEthereum?: boolean
 }
 
-function ScanAddress ({ className, onError, onScan, size, style }: Props): React.ReactElement<Props> {
+function ScanAddress ({ className, isEthereum, onError, onScan, size, style }: Props): React.ReactElement<Props> {
   const _onScan = useCallback(
     (data: string | null): void => {
       if (data) {
         try {
           const [prefix, content, genesisHash, ...name] = data.split(':');
-          const isValidPrefix = prefix === ADDRESS_PREFIX || prefix === SEED_PREFIX;
+          const isValidPrefix = isEthereum ? prefix === 'ethereum' : prefix === ADDRESS_PREFIX || prefix === SEED_PREFIX;
 
           assert(isValidPrefix, `Invalid prefix received, expected '${ADDRESS_PREFIX}/${SEED_PREFIX}' , found '${prefix}'`);
 
@@ -46,7 +47,7 @@ function ScanAddress ({ className, onError, onScan, size, style }: Props): React
         }
       }
     },
-    [onScan]
+    [onScan, isEthereum]
   );
 
   return (


### PR DESCRIPTION
This is the first step to solving error 2 of https://github.com/polkadot-js/apps/issues/5589#issuecomment-862105778 , which allows importing an ethereum account with QR code