### PR TITLE
Allow for multiple genesisHashes on keyring

### DIFF
--- a/packages/ui-keyring/src/Keyring.ts
+++ b/packages/ui-keyring/src/Keyring.ts
@@ -261,7 +261,9 @@ export class Keyring extends Base implements KeyringStruct {
   private allowGenesis (hashes: string[], json?: KeyringJson | { meta: KeyringJson$Meta } | null): boolean {
     if (json && json.meta) {
       if (json.meta.genesisHash) {
-        return hashes.includes(json.meta.genesisHash);
+        return Array.isArray(json.meta.genesisHash)
+          ? json.meta.genesisHash.some((h) => hashes.includes(h))
+          : hashes.includes(json.meta.genesisHash);
       } else if (json.meta.contract && json.meta.contract.genesisHash) {
         // for contracts, we only allow the primary/first hash
         return hashes[0] === json.meta.contract.genesisHash;

--- a/packages/ui-keyring/src/types.ts
+++ b/packages/ui-keyring/src/types.ts
@@ -13,7 +13,7 @@ export interface ContractMeta {
 
 export interface KeyringJson$Meta {
   contract?: ContractMeta;
-  genesisHash?: string | null;
+  genesisHash?: string[] | string | null;
   hardwareType?: 'ledger';
   isHardware?: boolean;
   isInjected?: boolean;


### PR DESCRIPTION
Backend for https://github.com/polkadot-js/extension/issues/461 & https://github.com/polkadot-js/apps/issues/5439 - allows for multiple genesis on a single account.

(Quite a far-reaching change, even as-is and unused)