### PR TITLE
🖼️ compatibility layer for H160 addresses

### DIFF
--- a/packages/vue-identicon/src/Identicon.ts
+++ b/packages/vue-identicon/src/Identicon.ts
@@ -7,7 +7,7 @@ import type { Prefix } from '@polkadot/util-crypto/address/types';
 import { defineComponent, h } from 'vue';
 
 import { isHex, isU8a, u8aToHex } from '@polkadot/util';
-import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
+import { decodeAddress, encodeAddress, isEthereumAddress } from '@polkadot/util-crypto';
 
 import { Beachball, Empty, Jdenticon, Polkadot } from './icons/index.js';
 import { adaptVNodeAttrs } from './util.js';
@@ -27,11 +27,19 @@ interface Data {
 
 const DEFAULT_SIZE = 64;
 
+function resolvePublicKey (value: string | Uint8Array, prefix?: Prefix): string {
+  if (isHex(value) && isEthereumAddress(value)) {
+    return value.padEnd(66, '0');
+  }
+
+  return isU8a(value) || isHex(value)
+  ? encodeAddress(value as string, prefix)
+  : value;
+}
+
 export function encodeAccount (value: string | Uint8Array, prefix?: Prefix): Account {
   try {
-    const address = isU8a(value) || isHex(value)
-      ? encodeAddress(value as string, prefix)
-      : value;
+    const address = resolvePublicKey(value, prefix)
     const publicKey = u8aToHex(decodeAddress(address, false, prefix));
 
     return { address, publicKey };

--- a/packages/vue-identicon/src/Identicon.ts
+++ b/packages/vue-identicon/src/Identicon.ts
@@ -27,7 +27,7 @@ interface Data {
 
 const DEFAULT_SIZE = 64;
 
-function resolvePublicKey(value: string | Uint8Array, prefix?: Prefix): string {
+function resolvePublicKey (value: string | Uint8Array, prefix?: Prefix): string {
   if (isHex(value) && isEthereumAddress(value)) {
     return value.padEnd(66, '0');
   }

--- a/packages/vue-identicon/src/Identicon.ts
+++ b/packages/vue-identicon/src/Identicon.ts
@@ -27,19 +27,19 @@ interface Data {
 
 const DEFAULT_SIZE = 64;
 
-function resolvePublicKey (value: string | Uint8Array, prefix?: Prefix): string {
+function resolvePublicKey(value: string | Uint8Array, prefix?: Prefix): string {
   if (isHex(value) && isEthereumAddress(value)) {
     return value.padEnd(66, '0');
   }
 
   return isU8a(value) || isHex(value)
-  ? encodeAddress(value as string, prefix)
-  : value;
+    ? encodeAddress(value as string, prefix)
+    : value;
 }
 
 export function encodeAccount (value: string | Uint8Array, prefix?: Prefix): Account {
   try {
-    const address = resolvePublicKey(value, prefix)
+    const address = resolvePublicKey(value, prefix);
     const publicKey = u8aToHex(decodeAddress(address, false, prefix));
 
     return { address, publicKey };


### PR DESCRIPTION
### Why

decentralized apps that work with substrate and use identicon.
However if they decide to add for example moonbeam, the identicon stops working.

### Fix

This is a simple fix that basically pads H160 address into Substrate public key and then app works normally

