### PR TITLE
:zap: increase internal vue-performance in Identicon

### DIFF
--- a/packages/vue-identicon/src/Identicon.ts
+++ b/packages/vue-identicon/src/Identicon.ts
@@ -99,7 +99,7 @@ export const Identicon = defineComponent({
           key: address,
           size: iconSize
         })
-      }, []);
+      }, () => []);
     } else if (type === 'jdenticon') {
       return h(Jdenticon, {
         ...adaptVNodeAttrs(
@@ -109,7 +109,7 @@ export const Identicon = defineComponent({
             size: iconSize
           }
         )
-      }, []);
+      }, () => []);
     } else if (type === 'substrate') {
       throw new Error('substrate type is not supported');
     }
@@ -128,9 +128,9 @@ export const Identicon = defineComponent({
           key: address,
           size: iconSize
         })
-      }, []);
+      }, () => []);
     } else {
-      return h(cmp, {}, []);
+      return h(cmp, {}, () => []);
     }
   },
   watch: {


### PR DESCRIPTION
## Context

As per patch merged in - https://github.com/kodadot/nft-gallery/pull/11246 
@preschian found out that a warning comes from the Vue identicon, this is caused by the fact that 3rd param of `h` should accept a function for slots rather than array. 

## Reading

https://github.com/kodadot/nft-gallery/pull/11246#issuecomment-2541257174

- https://github.com/vuejs/test-utils/issues/512
- https://github.com/vuejs/test-utils/blob/96ef276735ce188f50daa2b4143b80a4d716a44d/tests/element.spec.ts#L89-L100
- https://github.com/vuejs/test-utils/blob/96ef276735ce188f50daa2b4143b80a4d716a44d/tests/element.spec.ts#L109-L122