### PR TITLE
Add the type field to external keypair accounts

### DIFF
--- a/packages/ui-keyring/src/Keyring.ts
+++ b/packages/ui-keyring/src/Keyring.ts
@@ -33,7 +33,7 @@ export class Keyring extends Base implements KeyringStruct {
   };
 
   public addExternal (address: string | Uint8Array, meta: KeyringPair$Meta = {}): CreateResult {
-    const pair = this.keyring.addFromAddress(address, objectSpread<KeyringJson$Meta>({}, meta, { isExternal: true }), null);
+    const pair = this.keyring.addFromAddress(address, objectSpread<KeyringJson$Meta>({}, meta, { isExternal: true }), null, meta?.type);
 
     return {
       json: this.saveAccount(pair),


### PR DESCRIPTION
This allows hardware creation in the keyring to inherit the true type passed in why the meta object inside of the keypair